### PR TITLE
feat(ci): add SBOM inventory caller workflow for releases

### DIFF
--- a/.github/workflows/sbom-inventory.yml
+++ b/.github/workflows/sbom-inventory.yml
@@ -1,0 +1,45 @@
+# SBOM Inventory — caller workflow
+#
+# Triggers the reusable SBOM inventory workflow in transpara/ci whenever a
+# release is published on this repo. The inventory (two CycloneDX files, one
+# for Transpara first party components and one for third party components)
+# is attached back to the triggering release as audit evidence for EU CRA
+# Art. 13 and CISA 2025.
+#
+# Why this lives here and not in transpara/ci:
+#   This repo owns the platform release lifecycle. The inventory is produced
+#   at release time, referring to this release's own versions.yaml and
+#   components.yaml assets, and attached back to this release. The generator
+#   logic itself is the reusable workflow in transpara/ci so it can be
+#   maintained centrally without touching this repo.
+#
+# Token usage:
+#   GITHUB_TOKEN (default, same repo scope) is used by the reusable workflow
+#     to download versions.yaml and components.yaml from the triggering
+#     release and to upload the two CycloneDX outputs back to it.
+#   READ_ALL_TOKEN is passed through as gh_read_token so the inventory script
+#     can run gh release view against component repos like transpara/tsystem-api
+#     for cross repo SBOM discovery. Same token already used by
+#     joint-release.yml for cross repo reads.
+
+name: SBOM Inventory
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  # The reusable workflow attaches assets to the triggering release, which
+  # requires contents: write on this repo. Declared here so the caller's
+  # GITHUB_TOKEN has the scope the reusable job needs.
+  contents: write
+
+jobs:
+  inventory:
+    # Pinned to main. Consider pinning to a commit SHA if stricter supply
+    # chain immutability becomes a requirement.
+    uses: transpara/ci/.github/workflows/generate-sbom-inventory.yaml@main
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
+    secrets:
+      gh_read_token: ${{ secrets.READ_ALL_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the caller workflow that triggers the reusable SBOM inventory generator in `transpara/ci` whenever a release is published here. The inventory is attached back to the release as audit evidence.

## Why

`transpara/ci` now publishes a reusable workflow that produces two CycloneDX documents describing a platform release (first party components plus third party components) as evidence for EU CRA Art. 13 and CISA 2025. Running that generator at release time gives each release a self contained paper trail: an auditor can download the release assets and verify the platform inventory without consulting any external system.

## What

New file `.github/workflows/sbom-inventory.yml` that:

1. Triggers on `release.published`.
2. Calls `transpara/ci/.github/workflows/generate-sbom-inventory.yaml@main` with the release tag.
3. Passes `READ_ALL_TOKEN` through as `gh_read_token` for cross repo SBOM discovery against component repos like `transpara/tsystem-api`. Same token pattern already used by `joint-release.yml`.
4. Declares `contents: write` so the reusable workflow can attach the two CycloneDX outputs back to this release using the default `GITHUB_TOKEN`.

Outputs attached to each published release:

- `transpara-platform-{tag}-components.sbom.cdx.json` (Transpara first party)
- `transpara-platform-{tag}-thirdparty.sbom.cdx.json` (third party)

## Test plan

- [ ] Merge this PR.
- [ ] Cut the next joint release normally.
- [ ] Confirm the new workflow runs to completion (Actions tab).
- [ ] Confirm the two `transpara-platform-*.sbom.cdx.json` assets appear on the release alongside the existing ones.
- [ ] Open the components file and verify every component carries `transpara:per_image_sbom_status` and the document metadata lists `validation_mode`, `unverified_count`, and `unverified_components`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)