### PR TITLE
feat(release-notes): dedupe tinstaller and add a compact, audit-transparent format

### DIFF
--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -19,6 +19,9 @@ readonly ORG="${ORG:-transpara}"
 readonly INSTALLER_REPO="${INSTALLER_REPO:-tinstaller-releases}"
 readonly OUTPUT_FILE="${OUTPUT_FILE:-PLATFORM_RELEASE_NOTES.md}"
 
+# COMPONENTS yaml_path field that identifies the installer's own entry.
+readonly TINSTALLER_KEY="tinstaller.version"
+
 # Component registry — loaded from components.yaml (single source of truth).
 # Format after loading: yaml_path.version|display_name|github_repo|type|tag_prefix
 COMPONENTS=()
@@ -93,6 +96,27 @@ load_components_fallback() {
   )
 }
 
+# Ensures the installer's own component is present and leads COMPONENTS, so the
+# tinstaller section heads every generated view regardless of whether (or where)
+# the components.yaml asset lists it. Older assets omit the self-entry, so it is
+# synthesized when missing. An unchanged version is still skipped by
+# version_changed, like any other component.
+# Globals: COMPONENTS (augmented/reordered in place), TINSTALLER_KEY
+ensure_tinstaller_first() {
+  local front=() rest=() entry
+  for entry in "${COMPONENTS[@]}"; do
+    if [[ "${entry%%|*}" == "${TINSTALLER_KEY}" ]]; then
+      front+=("${entry}")
+    else
+      rest+=("${entry}")
+    fi
+  done
+  if (( ${#front[@]} == 0 )); then
+    front=("${TINSTALLER_KEY}|tinstaller|tinstaller|transpara|")
+  fi
+  COMPONENTS=("${front[@]}" "${rest[@]}")
+}
+
 # ── Logging ────────────────────────────────────────────────────────────
 log()    { echo "[*] $*" >&2; }
 warn()   { if [[ "${IS_CI}" == "true" ]]; then echo "::warning::$*" >&2; else echo "[!] WARNING: $*" >&2; fi; }
@@ -135,15 +159,26 @@ normalize_headers() {
   sed -E 's/^#{1,5} /##### /'
 }
 
-# Formats a version transition line for display.
+# Formats an upstream release body for inclusion: flattens its headers, then rewrites
+# bare 40-char commit SHAs into short clickable links. The commits live in the
+# component's own repo, not this one, so a bare SHA would never autolink on the
+# release page.
+# Arguments: $1 = github repo (under ORG) the body came from
+format_notes_body() {
+  local repo="$1"
+  normalize_headers \
+    | sed -E "s@\(([0-9a-f]{7})([0-9a-f]{33})\)@([\1](https://github.com/${ORG}/${repo}/commit/\1\2))@g"
+}
+
+# Formats a compact version transition fragment for a component heading.
 format_version_line() {
   local prev="$1" curr="$2"
   if [[ -n "${prev}" ]] && [[ "${prev}" != "null" ]] && [[ "${prev}" != "${curr}" ]]; then
-    echo "Previous: \`${prev}\` | Current: \`${curr}\`"
+    echo "\`${prev}\` → \`${curr}\`"
   elif [[ -z "${prev}" ]] || [[ "${prev}" == "null" ]]; then
-    echo "Current: \`${curr}\` (new component)"
+    echo "\`${curr}\` (new)"
   else
-    echo "Current: \`${curr}\`"
+    echo "\`${curr}\`"
   fi
 }
 
@@ -174,9 +209,8 @@ fetch_notes_between() {
 
   # No previous version — show only new version notes
   if [[ -z "${old_ver}" ]] || [[ "${old_ver}" == "null" ]]; then
-    echo "#### ${new_tag}"
     gh_retry gh release view "${new_tag}" --repo "${ORG}/${repo}" \
-      --json body --jq '.body' | normalize_headers || true
+      --json body --jq '.body' | format_notes_body "${repo}" || true
     echo ""
     return
   fi
@@ -199,18 +233,21 @@ fetch_notes_between() {
       "[.[] | select(.publishedAt > \"${old_date}\")] | reverse | .[].tagName" 2>/dev/null)
   else
     # Can't resolve dates — show just new version notes
-    echo "#### ${new_tag}"
     gh_retry gh release view "${new_tag}" --repo "${ORG}/${repo}" \
-      --json body --jq '.body' | normalize_headers || true
+      --json body --jq '.body' | format_notes_body "${repo}" || true
     echo ""
     return
   fi
 
   if [[ -n "${tags}" ]]; then
+    # Keep the per-tag marker only when aggregating multiple versions; for a single
+    # version the component heading already names it.
+    local tag_count
+    tag_count=$(grep -c . <<< "${tags}")
     while IFS= read -r tag; do
-      echo "#### ${tag}"
+      (( tag_count > 1 )) && echo "#### ${tag}"
       gh_retry gh release view "${tag}" --repo "${ORG}/${repo}" \
-        --json body --jq '.body' | normalize_headers || true
+        --json body --jq '.body' | format_notes_body "${repo}" || true
       echo ""
     done <<< "${tags}"
   fi
@@ -218,86 +255,136 @@ fetch_notes_between() {
 
 # ── Output generators ──────────────────────────────────────────────────
 
-generate_tinstaller_section() {
-  local curr_yaml="$1" prev_yaml="$2" workdir="$3"
-
-  local curr_ver prev_ver
-  curr_ver=$(get_version "${curr_yaml}" "tinstaller.version")
-  prev_ver=""
-  [[ -n "${prev_yaml}" ]] && prev_ver=$(get_version "${prev_yaml}" "tinstaller.version")
-
-  echo "### tInstaller"
-  format_version_line "${prev_ver}" "${curr_ver}"
-  echo ""
-  # Save notes to temp file for security section scanning
-  fetch_notes_between "tinstaller" "${prev_ver}" "${curr_ver}" \
-    | tee "${workdir}/tinstaller_notes.md"
-  echo "---"
-  echo ""
-}
-
-generate_transpara_sections() {
-  local curr_yaml="$1" prev_yaml="$2" workdir="$3"
-
-  mkdir -p "${workdir}/notes"
-  local pids=()
-  local names=()
-  declare -A SEEN_REPOS
-
+# Echoes one "display|prev|curr|repo|tag_prefix" line per changed, repo-deduplicated
+# first-party (transpara) component, in COMPONENTS order. Centralizes the detection
+# shared by the summary table and the per-component sections.
+# Globals: COMPONENTS
+collect_changed_transpara() {
+  local curr_yaml="$1" prev_yaml="$2"
+  local -A seen
+  local entry yaml_path name repo comp_type tag_prefix curr_ver prev_ver
+  local display count check check_repo
   for entry in "${COMPONENTS[@]}"; do
     IFS='|' read -r yaml_path name repo comp_type tag_prefix <<< "${entry}"
     [[ "${comp_type}" != "transpara" ]] && continue
+    if [[ "${repo}" != "—" ]] && [[ -n "${seen[${repo}]+_}" ]]; then continue; fi
 
-    # Deduplicate by github_repo — multi-image repos share the same repo
-    if [[ "${repo}" != "—" ]] && [[ -n "${SEEN_REPOS[${repo}]+_}" ]]; then
-      continue
-    fi
-
-    local curr_ver prev_ver
     curr_ver=$(get_version "${curr_yaml}" "${yaml_path}")
     prev_ver=""
     [[ -n "${prev_yaml}" ]] && prev_ver=$(get_version "${prev_yaml}" "${yaml_path}")
 
     if ! version_changed "${prev_ver}" "${curr_ver}"; then
-      [[ "${repo}" != "—" ]] && SEEN_REPOS[${repo}]=1
+      [[ "${repo}" != "—" ]] && seen[${repo}]=1
       continue
     fi
 
-    # For multi-image repos, use repo name as display name
-    local display="${name}"
-    local repo_count=0
+    # Multi-image repos (e.g. tcalc) share one repo; show the repo name once.
+    display="${name}"
+    count=0
     for check in "${COMPONENTS[@]}"; do
-      local check_repo
       IFS='|' read -r _ _ check_repo _ _ <<< "${check}"
-      [[ "${check_repo}" == "${repo}" ]] && repo_count=$((repo_count + 1))
+      [[ "${check_repo}" == "${repo}" ]] && count=$((count + 1))
     done
-    if [[ ${repo_count} -gt 1 ]]; then
-      display="${repo}"
-    fi
+    (( count > 1 )) && display="${repo}"
 
-    names+=("${display}")
-    [[ "${repo}" != "—" ]] && SEEN_REPOS[${repo}]=1
+    [[ "${repo}" != "—" ]] && seen[${repo}]=1
+    echo "${display}|${prev_ver}|${curr_ver}|${repo}|${tag_prefix}"
+  done
+}
 
-    # Write header + version line to temp file, then fetch notes in background
-    {
-      echo "### ${display}"
-      format_version_line "${prev_ver}" "${curr_ver}"
-      echo ""
-      fetch_notes_between "${repo}" "${prev_ver}" "${curr_ver}" "${tag_prefix}"
-      echo "---"
-      echo ""
-    } > "${workdir}/notes/${display}.md" 2>"${workdir}/notes/${display}.err" &
-    pids+=($!)
+# Emits a brief platform-level rollup at the top of the document: the installer
+# version transition and the first/third-party change counts. Pure templating of
+# already-computed state (no model, no extra network).
+# Arguments: $1 = changed-components file, $2 = curr versions.yaml,
+#            $3 = prev versions.yaml (may be empty), $4 = prev tag, $5 = target tag
+generate_release_summary() {
+  local changed_file="$1" curr_yaml="$2" prev_yaml="$3" prev_tag="$4" target_tag="$5"
+  local security_findings="$6"
+
+  local fp_count=0
+  [[ -s "${changed_file}" ]] && fp_count=$(grep -c . "${changed_file}")
+
+  local tp_count=0 entry yaml_path comp_type cur prev
+  for entry in "${COMPONENTS[@]}"; do
+    IFS='|' read -r yaml_path _ _ comp_type _ <<< "${entry}"
+    [[ "${comp_type}" != "thirdparty" ]] && continue
+    cur=$(get_version "${curr_yaml}" "${yaml_path}")
+    prev=""
+    [[ -n "${prev_yaml}" ]] && prev=$(get_version "${prev_yaml}" "${yaml_path}")
+    version_changed "${prev}" "${cur}" && tp_count=$((tp_count + 1))
   done
 
-  # Wait for all background fetches
+  echo "### Release Summary"
+  echo ""
+  if [[ -n "${prev_tag}" ]]; then
+    echo "- Platform installer: \`${prev_tag}\` → \`${target_tag}\`"
+  else
+    echo "- Platform installer: \`${target_tag}\` (initial release)"
+  fi
+  echo "- First-party components changed: ${fp_count}"
+  echo "- Third-party components changed: ${tp_count}"
+  if [[ -n "${security_findings}" ]]; then
+    echo "- Security keyword scan: matches detected (see Security-Relevant Changes below)"
+  else
+    echo "- Security keyword scan: no matches detected"
+  fi
+  echo ""
+}
+
+# Emits the top index table mapping each changed first-party component to its version
+# transition. Reads the lines produced by collect_changed_transpara.
+# Arguments: $1 = path to the changed-components file
+generate_summary_table() {
+  local changed_file="$1"
+  if [[ ! -s "${changed_file}" ]]; then
+    echo "_No first-party component changes in this release._"
+    echo ""
+    return
+  fi
+  echo "| Component | Previous | Current |"
+  echo "|-----------|----------|---------|"
+  local display prev_ver curr_ver repo tag_prefix prev_cell
+  while IFS='|' read -r display prev_ver curr_ver repo tag_prefix; do
+    [[ -z "${display}" ]] && continue
+    if [[ -n "${prev_ver}" ]] && [[ "${prev_ver}" != "null" ]]; then
+      prev_cell="\`${prev_ver}\`"
+    else
+      prev_cell="(new)"
+    fi
+    echo "| ${display} | ${prev_cell} | \`${curr_ver}\` |"
+  done < "${changed_file}"
+  echo ""
+}
+
+# Emits one section per changed first-party component: a single self-describing H3
+# (name + version transition) followed by the verbatim upstream notes. Fetches run in
+# parallel; sections are assembled in the order of the changed-components file.
+# Arguments: $1 = workdir, $2 = path to the changed-components file
+generate_transpara_sections() {
+  local workdir="$1" changed_file="$2"
+
+  mkdir -p "${workdir}/notes"
+  local pids=() names=()
+  local display prev_ver curr_ver repo tag_prefix
+
+  while IFS='|' read -r display prev_ver curr_ver repo tag_prefix; do
+    [[ -z "${display}" ]] && continue
+    names+=("${display}")
+    {
+      echo "### ${display}: $(format_version_line "${prev_ver}" "${curr_ver}")"
+      echo ""
+      fetch_notes_between "${repo}" "${prev_ver}" "${curr_ver}" "${tag_prefix}"
+    } > "${workdir}/notes/${display}.md" 2>"${workdir}/notes/${display}.err" &
+    pids+=($!)
+  done < "${changed_file}"
+
   for pid in "${pids[@]}"; do
     wait "${pid}" 2>/dev/null || true
   done
 
-  # Report errors
+  local name err_file notes_file
   for name in "${names[@]}"; do
-    local err_file="${workdir}/notes/${name}.err"
+    err_file="${workdir}/notes/${name}.err"
     if [[ -s "${err_file}" ]]; then
       warn "Error fetching notes for ${name}: $(cat "${err_file}")"
     fi
@@ -305,62 +392,41 @@ generate_transpara_sections() {
 
   # Assemble in original order
   for name in "${names[@]}"; do
-    local notes_file="${workdir}/notes/${name}.md"
-    if [[ -f "${notes_file}" ]]; then
-      cat "${notes_file}"
-    fi
+    notes_file="${workdir}/notes/${name}.md"
+    [[ -f "${notes_file}" ]] && cat "${notes_file}"
   done
 }
 
-# Scans fetched release notes for security-related changes.
-# Extracts matching lines from temp files already populated by generate_transpara_sections.
-generate_security_section() {
-  local workdir="$1"
-  local notes_dir="${workdir}/notes"
-
-  # Security keywords pattern (case-insensitive grep)
+# Scans fetched component notes for security keywords. Echoes the findings block
+# (matching lines grouped by component), or nothing when there are no matches.
+# Arguments: $1 = workdir (with a notes/ subdirectory populated by the fetch step)
+scan_security() {
+  local notes_dir="$1/notes"
   local pattern="CVE-|GHSA-|security|vulnerab|auth.*fix|XSS|CSRF|injection|privilege.escalat|access.control"
-
-  local findings=""
-
-  # Scan tinstaller notes if present
-  if [[ -f "${workdir}/tinstaller_notes.md" ]]; then
-    local matches
-    matches=$(grep -iE "${pattern}" "${workdir}/tinstaller_notes.md" 2>/dev/null || true)
+  local findings="" notes_file comp_name matches
+  [[ -d "${notes_dir}" ]] || return
+  for notes_file in "${notes_dir}"/*.md; do
+    [[ -f "${notes_file}" ]] || continue
+    comp_name=$(basename "${notes_file}" .md)
+    matches=$(grep -iE "${pattern}" "${notes_file}" 2>/dev/null || true)
     if [[ -n "${matches}" ]]; then
-      findings+="**tInstaller**"$'\n'
-      findings+="${matches}"$'\n\n'
+      findings+="**${comp_name}**"$'\n'"${matches}"$'\n\n'
     fi
-  fi
+  done
+  printf '%s' "${findings}"
+}
 
-  # Scan each component's notes
-  if [[ -d "${notes_dir}" ]]; then
-    for notes_file in "${notes_dir}"/*.md; do
-      [[ -f "${notes_file}" ]] || continue
-      local comp_name
-      comp_name=$(basename "${notes_file}" .md)
-      local matches
-      matches=$(grep -iE "${pattern}" "${notes_file}" 2>/dev/null || true)
-      if [[ -n "${matches}" ]]; then
-        findings+="**${comp_name}**"$'\n'
-        findings+="${matches}"$'\n\n'
-      fi
-    done
-  fi
-
+# Renders the security section from precomputed findings. Emits nothing when empty;
+# the all-clear state is reported in the Release Summary instead.
+# Arguments: $1 = findings block from scan_security
+render_security() {
+  local findings="$1"
+  [[ -z "${findings}" ]] && return
   echo "### Security-Relevant Changes"
   echo ""
-  if [[ -n "${findings}" ]]; then
-    echo "> The following changes were identified by keyword matching (CVE, security, vulnerability, auth fix, etc.)."
-    echo "> This is not a vulnerability assessment — review each item for applicability."
-    echo ""
-    echo "${findings}"
-  else
-    echo "No security-relevant changes detected in this release."
-    echo ""
-  fi
-  echo "---"
+  echo "> Identified by keyword matching (CVE, security, vulnerability, auth fix, etc.); not a vulnerability assessment, review each item for applicability."
   echo ""
+  echo "${findings}"
 }
 
 generate_thirdparty_table() {
@@ -385,17 +451,13 @@ generate_thirdparty_table() {
     fi
   done
 
+  # Render only when something changed; the all-clear is reported in the Release Summary.
+  [[ -z "${rows}" ]] && return
   echo "### Infrastructure & Third-Party"
   echo ""
-  if [[ -n "${rows}" ]]; then
-    echo "| Component | Previous | Current |"
-    echo "|-----------|----------|---------|"
-    echo -n "${rows}"
-  else
-    echo "No third-party version changes in this release."
-  fi
-  echo ""
-  echo "---"
+  echo "| Component | Previous | Current |"
+  echo "|-----------|----------|---------|"
+  echo -n "${rows}"
   echo ""
 }
 
@@ -406,8 +468,9 @@ generate_version_status() {
   echo ""
 
   # Check tinstaller + all transpara components for "behind latest"
-  # Include tag_prefix so we can strip it when comparing versions
-  local check_entries=("tinstaller.version|tinstaller|tinstaller|")
+  # Include tag_prefix so we can strip it when comparing versions.
+  # tinstaller arrives via COMPONENTS (ensured first), like any other component.
+  local check_entries=()
   local -A seen_repos_status
   for entry in "${COMPONENTS[@]}"; do
     IFS='|' read -r yaml_path name repo comp_type tag_prefix <<< "${entry}"
@@ -452,9 +515,7 @@ generate_version_status() {
   done
 
   if [[ -n "${behind}" ]]; then
-    echo "Components where the bundled version differs from the latest available release."
-    echo "Versions may be intentionally pinned for stability or compatibility."
-    echo "See [\`versions.yaml\`](https://github.com/${ORG}/${INSTALLER_REPO}/releases/tag/${target_tag}) attached to this release for the full manifest."
+    echo "Bundled versions differing from latest (may be intentionally pinned). Full manifest: [versions.yaml](https://github.com/${ORG}/${INSTALLER_REPO}/releases/tag/${target_tag})."
     echo ""
     echo "| Component | Bundled | Latest Available |"
     echo "|-----------|---------|------------------|"
@@ -462,6 +523,68 @@ generate_version_status() {
   else
     echo "All bundled component versions match their latest available releases."
   fi
+  echo ""
+}
+
+# Emits the compatibility ranges (from compatibility.yaml) and links to the release
+# manifests. Only links assets that actually exist in this release; renders nothing
+# when neither a compatibility table nor any manifest is available.
+# Arguments: $1 = compatibility.yaml path (may be empty), $2 = assets list file,
+#            $3 = target tag
+generate_compatibility_section() {
+  local compat_yaml="$1" assets_file="$2" target_tag="$3"
+  local base="https://github.com/${ORG}/${INSTALLER_REPO}/releases/download/${target_tag}"
+
+  # Link only the manifests that are actually attached to this release.
+  local links="" name
+  for name in compatibility.yaml versions.yaml components.yaml; do
+    grep -qx "${name}" "${assets_file}" 2>/dev/null && links+="[${name}](${base}/${name}) · "
+  done
+
+  local have_table="false"
+  [[ -n "${compat_yaml}" && -f "${compat_yaml}" ]] && have_table="true"
+  [[ "${have_table}" == "false" && -z "${links}" ]] && return
+
+  echo "### Compatibility"
+  echo ""
+
+  if [[ "${have_table}" == "true" ]]; then
+    echo "Tested ranges for core infrastructure components:"
+    echo ""
+    echo "| Component | Minimum | Max minor |"
+    echo "|-----------|---------|-----------|"
+    local key min max
+    while IFS= read -r key; do
+      [[ -z "${key}" ]] && continue
+      min=$(yq e ".[\"${key}\"].min // \"—\"" "${compat_yaml}" | tr -d '"')
+      max=$(yq e ".[\"${key}\"].max_minor // \"—\"" "${compat_yaml}" | tr -d '"')
+      echo "| ${key} | \`${min}\` | \`${max}\` |"
+    done < <(yq e 'keys | .[]' "${compat_yaml}")
+    echo ""
+  fi
+
+  [[ -n "${links}" ]] && { echo "Manifests: ${links% · }"; echo ""; }
+}
+
+# Lists the CycloneDX SBOM assets for the release as links. Self-adjusting: filters the
+# live asset inventory by the .sbom.cdx.json suffix, so new SBOMs appear automatically.
+# Arguments: $1 = assets list file, $2 = target tag
+generate_sbom_section() {
+  local assets_file="$1" target_tag="$2"
+  local base="https://github.com/${ORG}/${INSTALLER_REPO}/releases/download/${target_tag}"
+
+  local sboms
+  sboms=$(grep '\.sbom\.cdx\.json$' "${assets_file}" 2>/dev/null || true)
+  [[ -z "${sboms}" ]] && return
+
+  echo "### Software Bill of Materials"
+  echo ""
+  echo "CycloneDX SBOMs attached to this release:"
+  local name
+  while IFS= read -r name; do
+    [[ -z "${name}" ]] && continue
+    echo "* [${name}](${base}/${name})"
+  done <<< "${sboms}"
   echo ""
 }
 
@@ -523,22 +646,74 @@ main() {
     load_components_fallback
   fi
 
-  # Generate the release notes document
+  # Release asset inventory, used for manifest/SBOM links and the compatibility table.
+  local assets_file="${workdir}/assets.txt"
+  gh_retry gh release view "${target_tag}" --repo "${ORG}/${INSTALLER_REPO}" \
+    --json assets --jq '.assets[].name' > "${assets_file}" 2>/dev/null || true
+  local compat_yaml=""
+  if grep -qx "compatibility.yaml" "${assets_file}" 2>/dev/null \
+      && gh release download "${target_tag}" --repo "${ORG}/${INSTALLER_REPO}" \
+        --pattern "compatibility.yaml" --dir "${workdir}/current" 2>/dev/null; then
+    compat_yaml="${workdir}/current/compatibility.yaml"
+  fi
+
+  # Ensure tinstaller is present and leads, regardless of the asset's contents.
+  ensure_tinstaller_first
+
+  # Detect changed first-party components once; reused by the summary table and the
+  # per-component sections so detection is not duplicated.
+  local changed_file="${workdir}/changed.tsv"
+  collect_changed_transpara "${curr_yaml}" "${prev_yaml}" > "${changed_file}"
+
+  # Use the target tag's actual publish date, not the script's run date (which drifts
+  # on re-runs and local runs). Fall back to today (UTC) only if the release is not
+  # yet published. Not createdAt: that is the shared commit date across tags.
+  local release_date
+  release_date=$(gh_retry gh release view "${target_tag}" --repo "${ORG}/${INSTALLER_REPO}" \
+    --json publishedAt --jq '.publishedAt')
+  release_date="${release_date%%T*}"
+  [[ -z "${release_date}" || "${release_date}" == "null" ]] && release_date=$(date -u +%Y-%m-%d)
+
+  # Fetch component notes first (this populates ${workdir}/notes and captures the
+  # rendered sections); the Release Summary's security state needs the notes scanned
+  # up front, before anything is emitted.
+  local sections_md="${workdir}/sections.md"
+  : > "${sections_md}"
+  [[ -s "${changed_file}" ]] \
+    && generate_transpara_sections "${workdir}" "${changed_file}" > "${sections_md}"
+  local security_findings
+  security_findings=$(scan_security "${workdir}")
+
+  # Generate the release notes document. cat -s collapses any incidental double
+  # blank lines so the page stays dense.
   log "Generating release notes → ${OUTPUT_FILE}"
 
   {
-    echo "## Transpara Platform Release Notes"
-    echo "Consolidated release notes for all platform components."
+    echo "## Transpara Platform ${target_tag} Release Notes"
     echo ""
-    echo "Released: $(date +%Y-%m-%d) | Previous: \`${prev_tag:-initial}\` | Current: \`${target_tag}\`"
+    echo "Released: ${release_date} | Previous: \`${prev_tag:-initial}\` | Current: \`${target_tag}\`"
     echo ""
 
-    generate_tinstaller_section "${curr_yaml}" "${prev_yaml}" "${workdir}"
-    generate_transpara_sections "${curr_yaml}" "${prev_yaml}" "${workdir}"
-    generate_security_section "${workdir}"
+    generate_release_summary "${changed_file}" "${curr_yaml}" "${prev_yaml}" \
+      "${prev_tag}" "${target_tag}" "${security_findings}"
+    generate_summary_table "${changed_file}"
+
+    if [[ -s "${sections_md}" ]]; then
+      echo "---"
+      echo ""
+      cat "${sections_md}"
+    fi
+
+    # Detail sections appear only when they carry content; the all-clear states are
+    # reported in the Release Summary above.
+    echo "---"
+    echo ""
+    render_security "${security_findings}"
     generate_thirdparty_table "${curr_yaml}" "${prev_yaml}"
     generate_version_status "${curr_yaml}" "${workdir}" "${target_tag}"
-  } > "${OUTPUT_FILE}"
+    generate_compatibility_section "${compat_yaml}" "${assets_file}" "${target_tag}"
+    generate_sbom_section "${assets_file}" "${target_tag}"
+  } | cat -s > "${OUTPUT_FILE}"
 
   # Expose target tag for CI
   if [[ "${IS_CI}" == "true" ]] && [[ -n "${GITHUB_ENV:-}" ]]; then

--- a/scripts/test-release-notes.sh
+++ b/scripts/test-release-notes.sh
@@ -33,3 +33,81 @@ echo ""
 echo "══════════════════════════════════════════════════════════════"
 echo "  Saved to: $OUTPUT_FILE"
 echo "══════════════════════════════════════════════════════════════"
+
+echo ""
+echo "── Regression assertions ─────────────────────────────────────"
+
+fail() { echo "ASSERTION FAILED: $*" >&2; exit 1; }
+
+# Exactly one tinstaller component section (the header carries the version transition).
+count="$(grep -c '^### tinstaller:' "$OUTPUT_FILE" || true)"
+[[ "$count" == "1" ]] || fail "expected exactly 1 '### tinstaller:' section, found ${count}"
+
+# The first component section (its header carries a version transition) must be tinstaller.
+first="$(grep -m1 '^### .*: `' "$OUTPUT_FILE" || true)"
+[[ "$first" == "### tinstaller:"* ]] || fail "first component section is '${first}', want '### tinstaller: ...'"
+
+# No legacy capital-I duplicate anywhere.
+! grep -q 'tInstaller' "$OUTPUT_FILE" || fail "legacy 'tInstaller' string still present"
+
+# Commit SHAs must be linked, never a bare 40-char hex in parentheses.
+! grep -qE '\([0-9a-f]{40}\)' "$OUTPUT_FILE" || fail "bare 40-char commit SHA found (should be a short link)"
+
+# Link text must not be wrapped in backticks ([`x`](url) breaks rendering on GitHub).
+! grep -qE '\[`' "$OUTPUT_FILE" || fail "backtick-wrapped link text found (breaks links on GitHub)"
+
+# All-clear states live in the Release Summary, not as floating lines in the body.
+! grep -qE '^_No (security|third-party)' "$OUTPUT_FILE" \
+  || fail "floating empty-state line present (should be folded into the Release Summary)"
+grep -q '^- Security keyword scan:' "$OUTPUT_FILE" \
+  || fail "Release Summary is missing the security keyword scan bullet"
+
+# Detail sections must appear iff the Release Summary reports changes/items.
+tp_n="$(grep -m1 '^- Third-party components changed:' "$OUTPUT_FILE" | grep -oE '[0-9]+$' || true)"
+if [[ "$tp_n" == "0" ]]; then
+  ! grep -q '^### Infrastructure & Third-Party' "$OUTPUT_FILE" \
+    || fail "third-party section present though summary count is 0"
+else
+  grep -q '^### Infrastructure & Third-Party' "$OUTPUT_FILE" \
+    || fail "third-party section missing though summary count is ${tp_n}"
+fi
+if grep -q '^- Security keyword scan: no matches' "$OUTPUT_FILE"; then
+  ! grep -q '^### Security-Relevant Changes' "$OUTPUT_FILE" \
+    || fail "security section present though summary reports no matches"
+else
+  grep -q '^### Security-Relevant Changes' "$OUTPUT_FILE" \
+    || fail "security section missing though summary reports matches"
+fi
+
+# When a target tag is given, the Released date must be the tag's publish date, not today.
+if [[ -n "${1:-}" ]]; then
+  pub="$(gh release view "$1" --repo transpara/tinstaller-releases --json publishedAt --jq '.publishedAt' 2>/dev/null | cut -d'T' -f1 || true)"
+  if [[ -n "$pub" && "$pub" != "null" ]]; then
+    grep -q "^Released: ${pub} " "$OUTPUT_FILE" || fail "Released date is not the tag's publish date (${pub})"
+  fi
+fi
+
+# Release Summary heads the document, above the summary table.
+rs_line="$(grep -nm1 '^### Release Summary' "$OUTPUT_FILE" | cut -d: -f1 || true)"
+table_line="$(grep -nm1 '^| Component | Previous | Current |' "$OUTPUT_FILE" | cut -d: -f1 || true)"
+comp_line="$(grep -nm1 '^### .*: `' "$OUTPUT_FILE" | cut -d: -f1 || true)"
+[[ -n "$rs_line" && -n "$table_line" && "$rs_line" -lt "$table_line" ]] \
+  || fail "Release Summary not above the summary table (rs=${rs_line:-none}, table=${table_line:-none})"
+[[ -n "$table_line" && -n "$comp_line" && "$table_line" -lt "$comp_line" ]] \
+  || fail "summary table not found above first component (table=${table_line:-none}, comp=${comp_line:-none})"
+
+# Additive: the Version Status table must still be present (nothing was removed).
+grep -q '^### Version Status' "$OUTPUT_FILE" || fail "Version Status section was removed (changes must be additive)"
+
+# New footer sections must appear when their source assets exist for the target tag.
+if [[ -n "${1:-}" ]]; then
+  assets="$(gh release view "$1" --repo transpara/tinstaller-releases --json assets --jq '.assets[].name' 2>/dev/null || true)"
+  if grep -qx 'compatibility.yaml' <<<"$assets"; then
+    grep -q '^### Compatibility' "$OUTPUT_FILE" || fail "Compatibility section missing though compatibility.yaml asset exists"
+  fi
+  if grep -q '\.sbom\.cdx\.json$' <<<"$assets"; then
+    grep -q '^### Software Bill of Materials' "$OUTPUT_FILE" || fail "SBOM section missing though SBOM assets exist"
+  fi
+fi
+
+echo "All assertions passed."


### PR DESCRIPTION
## Why

The consolidated platform release notes (generated by `scripts/generate-release-notes.sh`
and published on each GitHub release) had two real problems plus a sparse, padded layout:

1. The tinstaller changelog appeared twice in every release, once as `### tInstaller`
   and once as `### tinstaller`. Two code paths rendered the same repo: a dedicated
   function and the `components.yaml` driven loop.
2. The `Released:` date was the date the script ran, not the date the release was
   actually published, so re-runs and local runs reported the wrong day.
3. For small releases the page was mostly padding: the version repeated across three
   nested headings, the Security and Third-Party sections always printed even when
   empty, and commit SHAs were 40 character strings that did not link.

The goal was to fix the bugs and make the document compact and easy to scan, while
staying fully transparent for audit (no hiding, no folding, upstream notes verbatim).

## What

Single code path and correctness fixes:
- Every component renders through one path. tinstaller is an ordinary component that
  the script forces to lead, and it is synthesized when an older `components.yaml`
  asset omits its entry, so the duplicate is gone for every tag.
- `Released:` now comes from the target tag's `publishedAt`, with a UTC today fallback
  only when the release is not yet published.

Presentation (compact, nothing hidden):
- One self-describing heading per component (`### name: prev to curr`), verbatim
  upstream notes, short clickable commit SHAs, and a blank line squeeze.
- New **Release Summary** at the top: installer transition, first and third party
  change counts, and the security keyword scan result. Pure templating of data the
  script already computes (no model, no extra calls).
- New **Compatibility** (tested ranges plus manifest links) and **Software Bill of
  Materials** sections, both derived live from the release assets so they self adjust.
- The Security and Third-Party detail sections appear only when they have content; the
  all-clear state is reported in the Release Summary instead of as floating lines.

Testing:
- `scripts/test-release-notes.sh` gained regression assertions for the dedupe, the
  publish date, linked SHAs (and no backticks in link text), the new sections, and
  summary to section consistency.

## Verification

Ran the local wrapper against four representative cases, all green:

| Scenario | Tags | Exercises |
|----------|------|-----------|
| Small | 0.285.0 / 0.284.0 | single first-party change, all-clear footer |
| Large, mixed styles | 0.283.0 / 0.280.0 | semantic-release and GitHub style bodies, multi-version ranges |
| Fallback | 0.250.0 / 0.249.0 | no `components.yaml` asset (built-in fallback) |
| With changes | 0.260.0 / 0.250.0 | third-party updates and a security keyword match (detail sections appear) |

`bash -n` passes on both scripts. `shellcheck` is advisory (not installed locally);
worth adding to CI.

## Out of scope (noted, not done here)

- `append_body: true` in `joint-release.yml` can append a second copy of the document
  if the generator re-runs for the same tag. Worth switching to `false` separately.
- An Installers and Assets table and an opt-in Upgrade Notes section were considered
  and deliberately left out (they duplicate GitHub's native asset list and would
  require human-authored or unverifiable content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
